### PR TITLE
Avoid double execution of the first task after 'stop()'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,12 @@ export class AwaitQueue
 		// Execute it.
 		await this.executeTask(pendingTask);
 
+		// If the task is stopped, ignore it.
+		if (pendingTask.stopped)
+		{
+			return;
+		}
+
 		// Remove the first pending task (the completed one) from the queue.
 		// NOTE: Ensure it remains being the same.
 		if (this.pendingTasks[0] === pendingTask)

--- a/src/test.ts
+++ b/src/test.ts
@@ -165,7 +165,7 @@ test('new task does not lead to next task execution if a (stopped) one is ongoin
 
 			executionsCount.set(taskName, ++executionCount);
 
-			resolve(true);
+			emitter.on('resolve-task-b', resolve);
 		});
 	};
 
@@ -182,6 +182,9 @@ test('new task does not lead to next task execution if a (stopped) one is ongoin
 
 	expect(executionsCount.get('taskA')).toBe(1);
 	expect(executionsCount.get('taskB')).toBe(1);
+
+	// Terminate task B.
+	emitter.emit('resolve-task-b');
 }, 1000);
 
 async function wait(timeMs: number): Promise<void>


### PR DESCRIPTION
The following scenario was broken:

* Task A is being executed.
* `stop()` is called and hence `pendingTasks` array is cleared.
* Task B is pushed into the queue.
* `next()` is called because `pendingTasks.length === 1`.
* `next()` executes task B.
* Tasks A finishes and `next()` is called again, which executes task B for the second time.